### PR TITLE
content/ohjeet/irssi-utf8.in: nykyään käytetään UTF-8:aa.

### DIFF
--- a/content/ohjeet/irssi-utf8.in
+++ b/content/ohjeet/irssi-utf8.in
@@ -9,7 +9,7 @@ UTF-8 on myös käytössä joissakin Linux-jakeluversioissa, kuten esimerkiksi U
 
 <p>
 Tämä ohje neuvoo Irssin konfiguroinnin siten, että irkkiin päin puhutaan oletuksena
-ISO 8859-15 -merkistöä ja päätteelle UTF-8:aa.
+UTF-8 -merkistöä.
 </p>
 
 <ol class="largespace">
@@ -36,11 +36,12 @@ Irssin merkistöksi päätteeseen päin asetetaan UTF-8:
 
 <li>
 <p>
-Turvallisin vaihtoehto on asettaa IRC-keskustelun merkistöksi ISO 8859-15, sillä UTF-8 ei ole vielä
-tuettu kaikilla ohjelmilla:
+Turvallisin vaihtoehto on asettaa IRC-keskustelun merkistöksi UTF-8, sillä 
+se on tuettu kaikilla nykyaikaisilla ohjelmilla ja sitä käytetään 
+kansainvälisillä kanavilla:
 </p>
 <pre>
-/set recode_out_default_charset ISO8859-15
+/set recode_out_default_charset UTF-8
 </pre>
 </li>
 


### PR DESCRIPTION
Minut ohjattiin tänne [UKK:sta](https://ukk.kapsi.fi/questions/333/miksi-kapsin-irssi-ohjeet-kehottavat-kayttamaan-iso8859-15-ulospain), josta löytyvät myös perusteet tälle muutokselle.

Tämä tiedosto jatkuu "Kanavanimet joissa on ääkkösiä" ja "UTF-8:n poistaminen käytöstä". En alkanut tekemään niille mitään, koska en ole varma päteekö UTF-8:n käyttöön ääkköselliset kanavanimet. UTF-8:n poistamisen käytöstä voisi myös poistaa, mutta odotan, että joku kehottaa tekemään niin ensin.
