### PR TITLE
Fix spam rule from example file contents

### DIFF
--- a/content/ohjeet/mailbox2maildir.in
+++ b/content/ohjeet/mailbox2maildir.in
@@ -31,7 +31,7 @@ MAILDIR=$HOME/Maildir/
 
 :0:
 * ^X-Spam-Status: Yes
-spam
+.spam/
 
 :0
 $MAILDIR


### PR DESCRIPTION
If spam rule is written wrong way "spam" but not ",spam/" it will create mbox file named spam instead of Maildir directory named .spam/ .